### PR TITLE
why is this ever showing why

### DIFF
--- a/iron-media-query.html
+++ b/iron-media-query.html
@@ -58,25 +58,26 @@ Example:
         type: Boolean,
         value: false
       },
-      
+
       /**
        * @type {function(MediaQueryList)}
-       */ 
+       */
       _boundMQHandler: {
         value: function() {
           return this.queryHandler.bind(this);
         }
       },
-      
+
       /**
        * @type {MediaQueryList}
-       */ 
+       */
       _mq: {
         value: null
       }
     },
 
     attached: function() {
+      this.style.display = 'none';
       this.queryChanged();
     },
 


### PR DESCRIPTION
In firefox, the element seems to have width 100%. In a different example, I've seen it have height 100% too. Neither of these make sense. Here it is, having a non zero width:
<img width="462" alt="screen shot 2015-11-10 at 4 23 53 pm" src="https://cloud.githubusercontent.com/assets/1369170/11080335/9260a338-87c7-11e5-870f-5060a9a15c89.png">

