### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "paper-styles": "polymerelements/paper-styles#^1.0.2",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,8 +17,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-
-    <link rel="import" href="../../paper-styles/paper-styles.html">
     <link rel="import" href="../../paper-styles/demo-pages.html">
     <link rel="import" href="../iron-media-query.html">
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -17,11 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
-
     <link rel="import" href="../iron-media-query.html">
-    <link rel="import" href="../../test-fixture/test-fixture.html">
-
+    
   </head>
   <body>
 


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way