### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-media-query.js
+++ b/iron-media-query.js
@@ -33,6 +33,7 @@ Example:
 Polymer({
 
   is: 'iron-media-query',
+  _template: null,
 
   properties: {
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336